### PR TITLE
Remove scratchblocksify function

### DIFF
--- a/pages/post/_post/embed.vue
+++ b/pages/post/_post/embed.vue
@@ -5,7 +5,7 @@
 <script>
 export default {
   colorMode() {
-    return 'light';
+    return "light";
   },
   head() {
     return {
@@ -24,26 +24,6 @@ export default {
         topic: {},
       },
     };
-  },
-  methods: {
-    scratchBlocksify() {
-      scratchblocks.renderMatching("pre.blocks:not(.scratchblockrendered)", {
-        style: "scratch2", // Optional
-      });
-      document
-        .querySelectorAll("pre.blocks:not(.scratchblockrendered)")
-        .forEach((i) => {
-          i.classList.add("scratchblockrendered");
-        });
-    },
-  },
-  updated: function () {
-    this.$nextTick(function () {
-      this.scratchBlocksify();
-    });
-  },
-  mounted: function () {
-    this.scratchBlocksify();
   },
   async fetch() {
     var postRes = await fetch(


### PR DESCRIPTION
Resolves #89
Removes the unneeded `scratchblocksify` function

Tested on CodeSandbox

EDIT: There is also a bug when you embed a post the links embedded will only redirect inside the iframe, which makes the report button unusable