### PR TITLE
open external links in new tab

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -1,14 +1,14 @@
 <template>
   <footer>
     ocular is an open source project, with styling aspects inspired by
-    <a href="https://scratch.mit.edu/users/maximouse" class="footer-link"
+    <a target="_blank" href="https://scratch.mit.edu/users/maximouse" class="footer-link"
       >@Maximouse</a
     >
     and Scratch by MIT<br />
     API and data from
-    <a class="footer-link" href="https://scratchdb.lefty.one/">@DatOneLefty</a>
+    <a class="footer-link" target="_blank" href="https://scratchdb.lefty.one/">@DatOneLefty</a>
     | authentication api from
-    <a class="footer-link" href="https://hamptonmoore.com">@herohamp</a>
+    <a class="footer-link" target="_blank" href="https://hamptonmoore.com">@herohamp</a>
     <br /><br />this forum viewer tool falls under Creative Commons
     Attribution-ShareAlike 2.0 license <br /><br />
     <nuxt-link class="footer-link" to="/docs/privacy">privacy</nuxt-link>

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -13,8 +13,8 @@
         </h1>
         <div class="margined">
           <nuxt-link to="/docs/about">about</nuxt-link> <span>|</span>
-          <a href="https://github.com/jeffalo/ocular" class="header-link">github</a> <span class="full">|</span>
-          <a href="https://scratchdb.lefty.one" class="header-link full">api and data from datonelefty</a>
+          <a target="_blank" href="https://github.com/jeffalo/ocular" class="header-link">github</a> <span class="full">|</span>
+          <a target="_blank" href="https://scratchdb.lefty.one" class="header-link full">api and data from datonelefty</a>
           <div v-if="$auth.loggedIn()" class="header-user">
             <nuxt-link :to="`/user/${$auth.user().name}`">@{{ $auth.user().name }}</nuxt-link> <span>|</span> <nuxt-link :to="`/starred`">starred</nuxt-link> | <nuxt-link :to="`/dashboard`">dashboard</nuxt-link> | <a @click="logout()" class="logout">logout</a>
           </div>

--- a/components/Post.vue
+++ b/components/Post.vue
@@ -5,7 +5,7 @@
       <nuxt-link :to="`/topic/${post.topic.id}`" class="topic-link">{{
         post.topic.title
       }}</nuxt-link>
-      <a
+      <a target="_blank"
         :href="`https://scratch.mit.edu/discuss/post/${post.id}`"
         class="view-scratch"
         >view on scratch</a
@@ -14,7 +14,7 @@
     <div class="post-wrap">
       <section class="main-content">
         <Render class="post-content" :content="post.content.html" />
-        <div class='post-footer'><ReactionButtons :post="post"/> | <span v-if="$auth.loggedIn()"> <Star :post="post"/> | </span><a :href='`https://scratch.mit.edu/discuss/misc/?action=report&post_id=${post.id}`'>Report</a></div>
+        <div class='post-footer'><ReactionButtons :post="post"/> | <span v-if="$auth.loggedIn()"> <Star :post="post"/> | </span><a target="_blank" :href='`https://scratch.mit.edu/discuss/misc/?action=report&post_id=${post.id}`'>Report</a></div>
       </section>
       <nav class="main-nav">
         <nuxt-link :to="`/user/${post.username}`" class="username">{{

--- a/pages/react/_id.vue
+++ b/pages/react/_id.vue
@@ -1,7 +1,7 @@
 <template>
     <main class="margined">
         <div v-if="$auth.loggedIn()" v-show="!loading">
-            are you sure you want to toggle reaction to <a :href="`https://scratch.mit.edu/discuss/post/${$route.params.id}`">{{ text }}</a> with "{{ $route.query.emoji }}"?
+            are you sure you want to toggle reaction to <a target="_blank" :href="`https://scratch.mit.edu/discuss/post/${$route.params.id}`">{{ text }}</a> with "{{ $route.query.emoji }}"?
             <button autofocus @click="react($route.params.id, $route.query.emoji)">yes</button>
             <button @click="close()">no</button>
         </div>

--- a/pages/user/_username.vue
+++ b/pages/user/_username.vue
@@ -6,6 +6,7 @@
       <div v-if="!$fetchState.pending">
         <h1 class="user-name">{{ user }}</h1>
         <h3 class="view-scratch"><a
+            target="_blank"
             :href="`https://scratch.mit.edu/users/${user}`"
             class="view-scratch"
         >scratch profile</a></h3>

--- a/pages/youtube/_id.vue
+++ b/pages/youtube/_id.vue
@@ -4,7 +4,7 @@
     <div class="margined">
       <h1>youtube</h1>
       <p>scratch converts youtube links to links to their own player page to prevent people from seeing youtube or something. this page is here to simulate the true scratch experience.</p>
-      <a :href="`https://youtube.com/watch?v=${$nuxt.context.route.params.id}`">watch on youtube</a>
+      <a :target="`_blank`" :href="`https://youtube.com/watch?v=${$nuxt.context.route.params.id}`">watch on youtube</a>
       <iframe class="youtube-player" type="text/html" width="538" height="324" :src="`https://www.youtube.com/embed/${$nuxt.context.route.params.id}`" frameborder="0" allowfullscreen="true"></iframe>
       <Footer />
     </div>


### PR DESCRIPTION
Currently most links replace the current tab, but I think opening any external link on the site in a new tab may make the site easier to use