### PR TITLE
Add in status and closed requirements

### DIFF
--- a/pages/search.vue
+++ b/pages/search.vue
@@ -89,6 +89,18 @@
                 requires that the resulting posts have this in their content
               </td>
             </tr>
+            <tr>
+              <td>closed</td>
+              <td>
+                requires the posts to be closed or not
+              </td>
+            </tr>
+            <tr>
+              <td>status</td>
+              <td>
+                requires the poster to be a member of the matching group (for example, +status:\"Scratch Team" returns only posts from the scratch team)
+              </td>
+            </tr>
           </tbody>
         </table>
         <br />

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -92,7 +92,7 @@
             <tr>
               <td>closed</td>
               <td>
-                requires the posts to be closed or not
+                specifies whether the containing topics are closed. use "1" to only get posts in topics that are closed, and "0" to get posts only in topics that are open
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
scratchdb supports `+status:"something"` and `+closed:"something"`. This pr adds them in. I'm not sure about the grammar though, especially [this line](https://github.com/jeffalo/ocular/blob/9f009448095c4ae6e6ef7716561460f52d5af277/pages/search.vue#L95)