### PR TITLE
Change "Scratch by MIT" to "the Scratch Foundation" in footer

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -4,7 +4,7 @@
     <a href="https://scratch.mit.edu/users/maximouse" class="footer-link"
       >@Maximouse</a
     >
-    and Scratch by MIT<br />
+    and the Scratch Foundation<br />
     API and data from
     <a class="footer-link" href="https://scratchdb.lefty.one/">@DatOneLefty</a>
     | authentication api from


### PR DESCRIPTION
Randomly came across #177 and thought I'd make a pull request.