### PR TITLE
Clarify that statuses must follow Scratch CGs

### DIFF
--- a/pages/dashboard/index.vue
+++ b/pages/dashboard/index.vue
@@ -28,7 +28,7 @@
           <br>
           <label for="color">favourite colour: </label><input name="color" type="color" class="color-input" v-model="color">
           <br>
-          <p>Your Ocular status must follow <a href="https://scratch.mit.edu/community_guidelines">Scratch's community guidelines</a>.</p>
+          <p>ocular statuses must follow <a href="https://scratch.mit.edu/community_guidelines">Scratch's community guidelines</a>.</p>
           <br>
           <div v-if="$auth.user().admin">
             <label for="banned">banned: </label><input type="checkbox" name="banned" v-model="banned">

--- a/pages/dashboard/index.vue
+++ b/pages/dashboard/index.vue
@@ -28,6 +28,8 @@
           <br>
           <label for="color">favourite colour: </label><input name="color" type="color" class="color-input" v-model="color">
           <br>
+          <p>Your Ocular status must follow <a href="https://scratch.mit.edu/community_guidelines">Scratch's community guidelines</a>.</p>
+          <br>
           <div v-if="$auth.user().admin">
             <label for="banned">banned: </label><input type="checkbox" name="banned" v-model="banned">
             <br><br>


### PR DESCRIPTION
A user pointed out that this isn't explicitly stated anywhere, so it might seem reasonable to assume that anything is allowed in statuses. This _might_ help reduce the (admittedly already small) amount of new rule-breaking statuses.